### PR TITLE
bump dependencies substreams-0.6 and prost 0.13.3, prep release to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ opt-level = 's'
 strip = "debuginfo"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Substreams development kit for Cosmos chains, contains Firehose Block model and helpers."
 authors = ["Denis <denis@pinax.network>", "Yaro <yaro@pinax.network>"]
@@ -21,5 +21,5 @@ license = "MIT"
 rust-version = "1.76"
 
 [workspace.dependencies]
-substreams-cosmos = { version = "0.1.*", path = "./substreams-cosmos" }
-substreams-cosmos-core = { version = "0.1.*", path = "./core" }
+substreams-cosmos = { version = "0.2.*", path = "./substreams-cosmos" }
+substreams-cosmos-core = { version = "0.2.*", path = "./core" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,12 +15,12 @@ readme = "../README.md"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-prost = "0.11"
-prost-types = "0.11"
-substreams = "^0.5.0"
+prost = "0.13.3"
+prost-types = "0.13.3"
+substreams = "^0.6.0"
 
 [build-dependencies]
-prost-build = "0.11"
+prost-build = "0.13.3"
 
 [dev-dependencies]
 anyhow = "1"

--- a/substreams-cosmos/Cargo.toml
+++ b/substreams-cosmos/Cargo.toml
@@ -15,7 +15,7 @@ readme = "../README.md"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-substreams = "^0.5"
+substreams = "^0.6.0"
 substreams-cosmos-core = { version = "0.*", path = "../core" }
 
 [dev-dependencies]


### PR DESCRIPTION
bump for compatibility with https://github.com/streamingfast/substreams-rs/releases/tag/v0.6.0