### PR TITLE
Hotfix : bump neoeinstein-prost version

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,14 +1,13 @@
 version: v2
 plugins:
-  - remote: buf.build/community/neoeinstein-prost:v0.2.2
+  - remote: buf.build/community/neoeinstein-prost:v0.4.0
     out: ./core/src/pb
     opt:
       - file_descriptor_set=false
 
-  - remote: buf.build/community/neoeinstein-prost-crate:v0.3.1
+  - remote: buf.build/community/neoeinstein-prost-crate:v0.4.1
     out: ./core/src/pb
     opt:
       - no_features
-
 # inputs:
 #   - module: buf.build/streamingfast/firehose-cosmos


### PR DESCRIPTION
Bumped `neoeinsteins-prost` versions to be compatible with `substreams` v0.6 according to <https://github.com/streamingfast/substreams-rs/releases/tag/v0.6.0>